### PR TITLE
Remove useless `keep me logged in` field

### DIFF
--- a/resources/view/login.html.twig
+++ b/resources/view/login.html.twig
@@ -3,8 +3,6 @@
 {{ form_row(form.email, {label: 'Email address'}) }}
 {{ form_row(form.password) }}
 
-{{ form_row(form.remember, {label: 'Keep me logged in'}) }}
-
 {% if forgottenPasswordRoute is not null %}
 <a class="forgotten-password" href="{{ url(forgottenPasswordRoute) }}">{{ 'Forgotten your password?' }}</a>
 {% endif %}

--- a/src/Controller/Authentication.php
+++ b/src/Controller/Authentication.php
@@ -156,10 +156,6 @@ class Authentication extends \Message\Cog\Controller\Controller
 			'attr' => (array_key_exists('redirect', $inputAttributes)) ? $inputAttributes['redirect'] : array(),
 		));
 
-		$handler->add('remember', 'checkbox', 'Keep me logged in', array(
-			'attr' => (array_key_exists('remember', $inputAttributes)) ? $inputAttributes['remember'] : array(),
-		))->val()->optional();
-
 		return $handler;
 	}
 }


### PR DESCRIPTION
This PR removes the 'Keep me logged in' field from the login screen as that functionality doesn't actually work