### PR TITLE
Better checks for user loading from session

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -16,7 +16,8 @@ class Services implements ServicesInterface
 
 		// Get the currently logged in user
 		$services['user.current'] = $services->factory(function($c) {
-			if ($user = $c['http.session']->get($c['cfg']->user->sessionName)) {
+			$user = $c['http.session']->get($c['cfg']->user->sessionName);
+			if ($user instanceof User\UserInterface) {
 				return $user;
 			}
 

--- a/src/EventListener/SessionRestore.php
+++ b/src/EventListener/SessionRestore.php
@@ -2,6 +2,7 @@
 
 namespace Message\User\EventListener;
 
+use Message\User;
 use Message\Cog\HTTP\Cookie;
 use Message\Cog\Event\EventListener;
 use Message\Cog\Event\SubscriberInterface;
@@ -39,7 +40,7 @@ class SessionRestore extends EventListener implements SubscriberInterface
 	public function restoreSessionFromCookie(GetResponseEvent $event)
 	{
 		// Skip this if there is already a user logged in
-		if (!($this->_services['user.current'] instanceof AnonymousUser)) {
+		if (!($this->_services['user.current'] instanceof User\AnonymousUser)) {
 			return false;
 		}
 
@@ -47,7 +48,7 @@ class SessionRestore extends EventListener implements SubscriberInterface
 			$user = $this->_services['user.session_hash']->getUserFromHash($cookie);
 
 			// If the hash is invalid, clear the cookie
-			if (!$user) {
+			if (!$user instanceof User\User) {
 				$this->_services['http.cookies']->add(new Cookie(
 					$this->_services['cfg']->user->cookieName,
 					null,
@@ -57,7 +58,7 @@ class SessionRestore extends EventListener implements SubscriberInterface
 				return false;
 			}
 
-			// Othrwise, set the user session
+			// Otherwise, set the user session
 			$this->_services['http.session']->set($this->_services['cfg']->user->sessionName, $user);
 
 			return true;


### PR DESCRIPTION
This PR should prevent the issue where sometimes a user is loaded as a string instead of a user instance. If the current user is loaded as a string, it is invalid and so the current user is logged out and anonymous