### PR TITLE
Add password property

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -23,6 +23,7 @@ class User implements UserInterface
 	public $title;
 	public $forename;
 	public $surname;
+	public $password;
 
 	public $lastLoginAt;
 	public $passwordRequestAt;


### PR DESCRIPTION
For some reason, the password property was accessed dynamically on this class, which has been causing a warning to throw for me on a class that extends the User, so this PR adds it