### PR TITLE
Allow Edit::setGroups() to take Group objects

### DIFF
--- a/src/Edit.php
+++ b/src/Edit.php
@@ -201,7 +201,7 @@ class Edit
 			}
 
 			if (!$group instanceof Group\GroupInterface) {
-				throw new \LogicException('All groups in array should be a string or an instance of `GroupInterface`');
+				throw new \LogicException('All groups in array should be a group name or an instance of `GroupInterface`');
 			}
 		});
 

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -195,9 +195,15 @@ class Edit
 		}
 
 		// Get the groups from the collection, ensuring they are valid
-		foreach ($groups as $i => $groupName) {
-			$groups[$i] = $this->_groups->get($groupName);
-		}
+		array_walk($groups, function (&$group) {
+			if (is_string($group)) {
+				$group = $this->_groups->get($group);
+			}
+
+			if (!$group instanceof Group\GroupInterface) {
+				throw new \LogicException('All groups in array should be a string or an instance of `GroupInterface`');
+			}
+		});
 
 		// Remove user from all groups
 		$this->_query->run('

--- a/src/Edit.php
+++ b/src/Edit.php
@@ -129,7 +129,7 @@ class Edit
 	 * Add a user to a group.
 	 *
 	 * @param User                $user
-	 * @param GroupGroupInterface $group
+	 * @param Group\GroupInterface $group
 	 *
 	 * @return bool
 	 */
@@ -194,16 +194,18 @@ class Edit
 			throw new InvalidArgumentException('Cannot edit a user with no ID');
 		}
 
-		// Get the groups from the collection, ensuring they are valid
-		array_walk($groups, function (&$group) {
-			if (is_string($group)) {
-				$group = $this->_groups->get($group);
-			}
+		$groupObjects = [];
 
+		foreach ($groups as $group) {
+			$group = is_string($group) ? $this->_groups->get($group) : $group;
 			if (!$group instanceof Group\GroupInterface) {
 				throw new \LogicException('All groups in array should be a group name or an instance of `GroupInterface`');
 			}
-		});
+
+			$groupObjects[$group->getName()] = $group;
+		}
+
+		$groups = $groupObjects;
 
 		// Remove user from all groups
 		$this->_query->run('
@@ -226,7 +228,6 @@ class Edit
 			$insertValues[] = $group->getName();
 		}
 		$insertQuery = substr($insertQuery, 0, -1);
-
 		$this->_query->run('
 			INSERT INTO
 				user_group (`user_id`, `group_name`)


### PR DESCRIPTION
So, the Edit::setGroups() class only allowed an array of strings, instead of instances of GroupInterface. That's super dumb, because the other methods all only take instances of GroupInterface, ~~so I used the `array_walk()` function to loop through~~ created a new array and converted string names to group objects, and leave them be otherwise. 